### PR TITLE
#137599141 Fix exercise cache muscles 

### DIFF
--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -21,8 +21,10 @@ import logging
 import bleach
 
 from django.db import models
+from django.db.models import Q
 from django.template.loader import render_to_string
-from django.template.defaultfilters import slugify  # django.utils.text.slugify in django 1.5!
+# django.utils.text.slugify in django 1.5!
+from django.template.defaultfilters import slugify
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.utils.translation import ugettext_lazy as _
@@ -31,6 +33,7 @@ from django.utils import translation
 from django.core.urlresolvers import reverse
 from django.core import mail
 from django.core.cache import cache
+from django.core.cache.utils import make_template_fragment_key
 from django.core.validators import MinLengthValidator
 from django.conf import settings
 
@@ -76,6 +79,23 @@ class Muscle(models.Model):
         Muscle has no owner information
         '''
         return False
+
+    def delete(self, *args, **kwargs):
+        '''
+        Reset all cached infos
+        '''
+        # get exercises which contain current muscle
+        exercises = Exercise.objects.filter(
+            Q(muscles=self) | Q(muscles_secondary=self)).all()
+
+        delete_template_fragment_cache('muscle-overview', self.id)
+        # Cached template fragments
+        for exercise in exercises:
+            for language in Language.objects.all():
+                delete_template_fragment_cache(
+                    'exercise-detail-muscles', exercise.id, language.id)
+
+        super(Muscle, self).delete(*args, **kwargs)
 
 
 @python_2_unicode_compatible
@@ -141,7 +161,8 @@ class ExerciseCategory(models.Model):
         # Cached template fragments
         for language in Language.objects.all():
             delete_template_fragment_cache('exercise-overview', language.id)
-            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+            delete_template_fragment_cache(
+                'exercise-overview-mobile', language.id)
 
     def delete(self, *args, **kwargs):
         '''
@@ -149,7 +170,8 @@ class ExerciseCategory(models.Model):
         '''
         for language in Language.objects.all():
             delete_template_fragment_cache('exercise-overview', language.id)
-            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+            delete_template_fragment_cache(
+                'exercise-overview-mobile', language.id)
 
         super(ExerciseCategory, self).delete(*args, **kwargs)
 
@@ -185,7 +207,8 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
     '''Main muscles trained by the exercise'''
 
     muscles_secondary = models.ManyToManyField(Muscle,
-                                               verbose_name=_('Secondary muscles'),
+                                               verbose_name=_(
+                                                   'Secondary muscles'),
                                                related_name='secondary_muscles',
                                                blank=True)
     '''Secondary muscles trained by the exercise'''
@@ -239,8 +262,11 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         for language in Language.objects.all():
             delete_template_fragment_cache('muscle-overview', language.id)
             delete_template_fragment_cache('exercise-overview', language.id)
-            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+            delete_template_fragment_cache(
+                'exercise-overview-mobile', language.id)
             delete_template_fragment_cache('equipment-overview', language.id)
+            cache.delete(make_template_fragment_key(
+                'exercise-detail-muscles', [self.id, language.id]))
 
         # Cached workouts
         for set in self.set_set.all():
@@ -258,8 +284,11 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         for language in Language.objects.all():
             delete_template_fragment_cache('muscle-overview', language.id)
             delete_template_fragment_cache('exercise-overview', language.id)
-            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+            delete_template_fragment_cache(
+                'exercise-overview-mobile', language.id)
             delete_template_fragment_cache('equipment-overview', language.id)
+            cache.delete(make_template_fragment_key(
+                'exercise-detail-muscles', [self.id, language.id]))
 
         # Cached workouts
         for set in self.set_set.all():
@@ -307,9 +336,11 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         except User.DoesNotExist:
             return
         if self.license_author and user.email:
-            translation.activate(user.userprofile.notification_language.short_name)
+            translation.activate(
+                user.userprofile.notification_language.short_name)
             url = request.build_absolute_uri(self.get_absolute_url())
-            subject = _('Exercise was successfully added to the general database')
+            subject = _(
+                'Exercise was successfully added to the general database')
             context = {
                 'exercise': self.name,
                 'url': url,
@@ -364,7 +395,8 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel, models.Model)
     '''The exercise the image belongs to'''
 
     image = models.ImageField(verbose_name=_('Image'),
-                              help_text=_('Only PNG and JPEG formats are supported'),
+                              help_text=_(
+                                  'Only PNG and JPEG formats are supported'),
                               upload_to=exercise_image_upload_dir)
     '''Uploaded image'''
 
@@ -387,7 +419,8 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel, models.Model)
         Only one image can be marked as main picture at a time
         '''
         if self.is_main:
-            ExerciseImage.objects.filter(exercise=self.exercise).update(is_main=False)
+            ExerciseImage.objects.filter(
+                exercise=self.exercise).update(is_main=False)
             self.is_main = True
         else:
             if ExerciseImage.objects.accepted().filter(exercise=self.exercise).count() == 0 \
@@ -402,7 +435,8 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel, models.Model)
         for language in Language.objects.all():
             delete_template_fragment_cache('muscle-overview', language.id)
             delete_template_fragment_cache('exercise-overview', language.id)
-            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+            delete_template_fragment_cache(
+                'exercise-overview-mobile', language.id)
             delete_template_fragment_cache('equipment-overview', language.id)
 
         # And go on
@@ -417,7 +451,8 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel, models.Model)
         for language in Language.objects.all():
             delete_template_fragment_cache('muscle-overview', language.id)
             delete_template_fragment_cache('exercise-overview', language.id)
-            delete_template_fragment_cache('exercise-overview-mobile', language.id)
+            delete_template_fragment_cache(
+                'exercise-overview-mobile', language.id)
             delete_template_fragment_cache('equipment-overview', language.id)
 
         # Make sure there is always a main image
@@ -428,10 +463,10 @@ class ExerciseImage(AbstractSubmissionModel, AbstractLicenseModel, models.Model)
                 .filter(is_main=False) \
                 .count():
 
-                image = ExerciseImage.objects.accepted() \
-                    .filter(exercise=self.exercise, is_main=False)[0]
-                image.is_main = True
-                image.save()
+            image = ExerciseImage.objects.accepted() \
+                .filter(exercise=self.exercise, is_main=False)[0]
+            image.is_main = True
+            image.save()
 
     def get_owner_object(self):
         '''

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -495,6 +495,7 @@ class ExercisesCacheTestCase(WorkoutManagerTestCase):
 
         new_exercise_overview = cache.get(get_template_cache_name('exercise-detail-muscles', 2))
 
+
 class WorkoutCacheTestCase(WorkoutManagerTestCase):
     '''
     Workout cache test case

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -475,6 +475,25 @@ class ExercisesCacheTestCase(WorkoutManagerTestCase):
         else:
             self.assertNotEqual(old_exercise_overview_mobile, new_exercise_overview_mobile)
 
+    def test_muscles_cache_update(self):
+        '''
+        Test that the template cache for the overview is correctly reset when
+        performing certain operations
+        '''
+        self.client.get(reverse('exercise:exercise:view', kwargs={'id': 2}))
+
+        old_exercise_overview = cache.get(get_template_cache_name('exercise-detail-muscles', 2))
+
+        muscle = Muscle.objects.get(pk=2)
+        muscle.delete()
+
+        self.assertFalse(cache.get(get_template_cache_name('exercise-detail-muscles', 2)))
+
+        self.client.get(reverse('exercise:exercise:overview'))
+        self.client.get(reverse('exercise:muscle:overview'))
+        self.client.get(reverse('exercise:exercise:view', kwargs={'id': 2}))
+
+        new_exercise_overview = cache.get(get_template_cache_name('exercise-detail-muscles', 2))
 
 class WorkoutCacheTestCase(WorkoutManagerTestCase):
     '''


### PR DESCRIPTION
### What does this PR do?

Resets cache after deleting a muscle.

### Description of Task to be completed?

After deleting a muscle, it keeps appearing in descriptions.

### How should this be manually tested?

On editing muscles of an exercise, check if the changes to the affected muscles is reflected
on the description and the images of muscles on exercise overview

### Any background context you want to provide?

This is probably due to the cache not being correctly reset.

### What are the relevant pivotal tracker stories?

https://www.pivotaltracker.com/n/projects/1951663/stories/137599141
